### PR TITLE
require all 12 paper-key phrases (start flow)

### DIFF
--- a/breadwallet/src/FlowControllers/StartFlowPresenter.swift
+++ b/breadwallet/src/FlowControllers/StartFlowPresenter.swift
@@ -176,15 +176,10 @@ class StartFlowPresenter : Subscriber {
     }
 
     private func pushConfirmPaperPhraseViewController(pin: String) {
-        let confirmViewController = ConfirmPaperPhraseViewController(store: store, walletManager: walletManager, pin: pin, callback: { [weak self] in
-            guard let myself = self else { return }
-            myself.store.perform(action: Alert.Show(.paperKeySet(callback: {
-                self?.store.perform(action: HideStartFlow())
-            })))
-        })
-        confirmViewController.title = S.SecurityCenter.Cells.paperKeyTitle
-        navigationController?.navigationBar.tintColor = .white
-        navigationController?.pushViewController(confirmViewController, animated: true)
+        let recoverWalletViewController = EnterPhraseViewController(store: store, walletManager: walletManager, reason: .validateForCreatingWallet({
+            self.store.perform(action: HideStartFlow())
+        }))
+        navigationController?.pushViewController(recoverWalletViewController, animated: true)
     }
 
     private func presentLoginFlow(isPresentedForLock: Bool) {

--- a/breadwallet/src/ViewControllers/EnterPhraseViewController.swift
+++ b/breadwallet/src/ViewControllers/EnterPhraseViewController.swift
@@ -12,6 +12,7 @@ enum PhraseEntryReason {
     case setSeed(EnterPhraseCallback)
     case validateForResettingPin(EnterPhraseCallback)
     case validateForWipingWallet(()->Void)
+    case validateForCreatingWallet(()->Void)
 }
 
 typealias EnterPhraseCallback = (String) -> Void
@@ -32,6 +33,8 @@ class EnterPhraseViewController : UIViewController, UIScrollViewDelegate, Custom
             self.customTitle = S.RecoverWallet.headerResetPin
         case .validateForWipingWallet(_):
             self.customTitle = S.WipeWallet.title
+        case .validateForCreatingWallet(_):
+            self.customTitle = S.StartPaperPhrase.buttonTitle
         }
 
         super.init(nibName: nil, bundle: nil)
@@ -150,6 +153,10 @@ class EnterPhraseViewController : UIViewController, UIScrollViewDelegate, Custom
             saveEvent("enterPhrase.wipeWallet")
             titleLabel.text = S.WipeWallet.title
             subheader.text = S.WipeWallet.instruction
+        case .validateForCreatingWallet(_):
+            saveEvent("enterPhrase.createWallet")
+            titleLabel.text = S.StartPaperPhrase.buttonTitle
+            subheader.text = S.StartPaperPhrase.body
         }
 
         scrollView.delegate = self
@@ -177,6 +184,9 @@ class EnterPhraseViewController : UIViewController, UIScrollViewDelegate, Custom
             UserDefaults.writePaperPhraseDate = Date()
             return callback(phrase)
         case .validateForWipingWallet(let callback):
+            guard self.walletManager.authenticate(phrase: phrase) else { errorLabel.isHidden = false; return }
+            return callback()
+        case .validateForCreatingWallet(let callback):
             guard self.walletManager.authenticate(phrase: phrase) else { errorLabel.isHidden = false; return }
             return callback()
         }


### PR DESCRIPTION
This commit uses `EnterPhraseViewController` with the reason `validateForCreatingWallet` to require user to enter all 12 paper-key phrases on initial launch. `ConfirmPaperPhraseViewController` is no longer being used and may be deprecated in the future.