### PR TITLE
[Bugfix] Renamed enum from State

### DIFF
--- a/loafwallet.xcodeproj/project.pbxproj
+++ b/loafwallet.xcodeproj/project.pbxproj
@@ -4592,7 +4592,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = ZV7987N2ZC;
 				INFOPLIST_FILE = TodayExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -4931,7 +4931,7 @@
 				CURRENT_PROJECT_VERSION = 252;
 				DEVELOPMENT_TEAM = ZV7987N2ZC;
 				INFOPLIST_FILE = TodayExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -5064,7 +5064,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = ZV7987N2ZC;
 				INFOPLIST_FILE = TodayExtension/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/loafwallet/TransactionTableViewCells.swift
+++ b/loafwallet/TransactionTableViewCells.swift
@@ -262,7 +262,7 @@ enum PromptType {
         }
     }
 
-    func shouldPrompt(walletManager: WalletManager, state: State) -> Bool {
+    func shouldPrompt(walletManager: WalletManager, state: ReduxState) -> Bool {
          
         switch self {
         case .biometrics:

--- a/loafwallet/src/FlowControllers/StartFlowPresenter.swift
+++ b/loafwallet/src/FlowControllers/StartFlowPresenter.swift
@@ -48,7 +48,7 @@ class StartFlowPresenter : Subscriber {
                         callback: { _ in self.presentLoginFlow(isPresentedForLock: true) })
     }
 
-    private func handleStartFlowChange(state: State) {
+    private func handleStartFlowChange(state: ReduxState) {
         if state.isStartFlowVisible {
             guardProtected(queue: DispatchQueue.main) { [weak self] in
                 self?.presentStartFlow()
@@ -58,7 +58,7 @@ class StartFlowPresenter : Subscriber {
         }
     }
 
-    private func handleLoginRequiredChange(state: State) {
+    private func handleLoginRequiredChange(state: ReduxState) {
         if state.isLoginRequired {
             presentLoginFlow(isPresentedForLock: false)
         } else {

--- a/loafwallet/src/SimpleRedux.swift
+++ b/loafwallet/src/SimpleRedux.swift
@@ -8,8 +8,8 @@
 
 import UIKit
 
-typealias Reducer = (State) -> State
-typealias Selector = (_ oldState: State, _ newState: State) -> Bool
+typealias Reducer = (ReduxState) -> ReduxState
+typealias Selector = (_ oldState: ReduxState, _ newState: ReduxState) -> Bool
 
 protocol Action {
     var reduce: Reducer { get }
@@ -24,11 +24,11 @@ extension Subscriber {
     }
 }
 
-typealias StateUpdatedCallback = (State) -> Void
+typealias StateUpdatedCallback = (ReduxState) -> Void
 
 struct Subscription {
-    let selector: ((_ oldState: State, _ newState: State) -> Bool)
-    let callback: (State) -> Void
+    let selector: ((_ oldState: ReduxState, _ newState: ReduxState) -> Bool)
+    let callback: (ReduxState) -> Void
 }
 
 struct Trigger {
@@ -148,13 +148,13 @@ class Store {
 
     //Subscription callback is immediately called with current State value on subscription
     //and then any time the selected value changes
-    func subscribe(_ subscriber: Subscriber, selector: @escaping Selector, callback: @escaping (State) -> Void) {
+    func subscribe(_ subscriber: Subscriber, selector: @escaping Selector, callback: @escaping (ReduxState) -> Void) {
         lazySubscribe(subscriber, selector: selector, callback: callback)
         callback(state)
     }
 
     //Same as subscribe(), but doesn't call the callback with current state upon subscription
-    func lazySubscribe(_ subscriber: Subscriber, selector: @escaping Selector, callback: @escaping (State) -> Void) {
+    func lazySubscribe(_ subscriber: Subscriber, selector: @escaping Selector, callback: @escaping (ReduxState) -> Void) {
         let key = subscriber.hashValue
         let subscription = Subscription(selector: selector, callback: callback)
         if subscriptions[key] != nil {
@@ -180,7 +180,7 @@ class Store {
     }
 
     //MARK: - Private
-    private(set) var state = State.initial {
+    private(set) var state = ReduxState.initial {
         didSet {
             subscriptions
                 .flatMap { $0.value } //Retreive all subscriptions (subscriptions is a dictionary)

--- a/loafwallet/src/SimpleRedux/Actions.swift
+++ b/loafwallet/src/SimpleRedux/Actions.swift
@@ -17,7 +17,7 @@ struct ShowStartFlow : Action {
 
 struct HideStartFlow : Action {
     let reduce: Reducer = { state in
-        return State(isStartFlowVisible: false,
+        return ReduxState(isStartFlowVisible: false,
                      isLoginRequired: state.isLoginRequired,
                      rootModal: .none,
                      walletState: state.walletState,
@@ -39,7 +39,7 @@ struct HideStartFlow : Action {
 
 struct Reset : Action {
     let reduce: Reducer = { _ in
-        return State.initial.clone(isLoginRequired: false)
+        return ReduxState.initial.clone(isLoginRequired: false)
     }
 }
 
@@ -240,10 +240,10 @@ enum UpdateFees {
 }
 
 
-//MARK: - State Creation Helpers
-extension State {
-    func clone(isStartFlowVisible: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+//MARK: - ReduxState Creation Helpers
+extension ReduxState {
+    func clone(isStartFlowVisible: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -261,8 +261,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func rootModal(_ type: RootModal) -> State {
-        return State(isStartFlowVisible: false,
+    func rootModal(_ type: RootModal) -> ReduxState {
+        return ReduxState(isStartFlowVisible: false,
                      isLoginRequired: isLoginRequired,
                      rootModal: type,
                      walletState: walletState,
@@ -280,8 +280,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(pasteboard: String?) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(pasteboard: String?) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -299,8 +299,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(walletSyncProgress: Double, timestamp: UInt32) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(walletSyncProgress: Double, timestamp: UInt32) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletSyncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: timestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -318,8 +318,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(syncState: SyncState) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(syncState: SyncState) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -337,8 +337,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(balance: UInt64) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(balance: UInt64) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -356,8 +356,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(transactions: [Transaction]) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(transactions: [Transaction]) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -375,8 +375,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(walletName: String) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(walletName: String) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletName, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -394,8 +394,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(walletSyncingErrorMessage: String?) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(walletSyncingErrorMessage: String?) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: walletState.isRescanning),
@@ -413,8 +413,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(walletCreationDate: Date) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(walletCreationDate: Date) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletCreationDate, isRescanning: walletState.isRescanning),
@@ -432,8 +432,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isRescanning: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isRescanning: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: WalletState(isConnected: walletState.isConnected, syncProgress: walletState.syncProgress, syncState: walletState.syncState, balance: walletState.balance, transactions: walletState.transactions, lastBlockTimestamp: walletState.lastBlockTimestamp, name: walletState.name, creationDate: walletState.creationDate, isRescanning: isRescanning),
@@ -451,8 +451,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isLtcSwapped: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isLtcSwapped: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -470,8 +470,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isLoginRequired: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isLoginRequired: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -489,8 +489,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(currentRate: Rate, rates: [Rate]) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(currentRate: Rate, rates: [Rate]) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -508,8 +508,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(currentRate: Rate) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(currentRate: Rate) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -527,8 +527,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(alert: AlertType?) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(alert: AlertType?) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -546,8 +546,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isBiometricsEnabled: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isBiometricsEnabled: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -565,8 +565,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(defaultCurrencyCode: String) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(defaultCurrencyCode: String) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -584,8 +584,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(recommendRescan: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(recommendRescan: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -603,8 +603,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isLoadingTransactions: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isLoadingTransactions: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -622,8 +622,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(maxDigits: Int) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(maxDigits: Int) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -641,8 +641,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isPushNotificationsEnabled: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isPushNotificationsEnabled: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -660,8 +660,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(isPromptingBiometrics: Bool) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(isPromptingBiometrics: Bool) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -679,8 +679,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(pinLength: Int) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(pinLength: Int) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,
@@ -698,8 +698,8 @@ extension State {
                      pinLength: pinLength,
                      fees: fees)
     }
-    func clone(fees: Fees) -> State {
-        return State(isStartFlowVisible: isStartFlowVisible,
+    func clone(fees: Fees) -> ReduxState {
+        return ReduxState(isStartFlowVisible: isStartFlowVisible,
                      isLoginRequired: isLoginRequired,
                      rootModal: rootModal,
                      walletState: walletState,

--- a/loafwallet/src/SimpleRedux/State.swift
+++ b/loafwallet/src/SimpleRedux/State.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-struct State {
+struct ReduxState {
     let isStartFlowVisible: Bool
     let isLoginRequired: Bool
     let rootModal: RootModal
@@ -28,9 +28,9 @@ struct State {
     let fees: Fees
 }
 
-extension State {
-    static var initial: State {
-        return State(   isStartFlowVisible: false,
+extension ReduxState {
+    static var initial: ReduxState {
+        return ReduxState (   isStartFlowVisible: false,
                         isLoginRequired: true,
                         rootModal: .none,
                         walletState: WalletState.initial,

--- a/loafwallet/src/ViewControllers/ConfirmationViewController.swift
+++ b/loafwallet/src/ViewControllers/ConfirmationViewController.swift
@@ -11,7 +11,7 @@ import LocalAuthentication
 
 class ConfirmationViewController : UIViewController, ContentBoxPresenter {
 
-    init(amount: Satoshis, fee: Satoshis, feeType: FeeType, state: State, selectedRate: Rate?, minimumFractionDigits: Int?, address: String, isUsingBiometrics: Bool, isDonation: Bool = false) {
+    init(amount: Satoshis, fee: Satoshis, feeType: FeeType, state: ReduxState, selectedRate: Rate?, minimumFractionDigits: Int?, address: String, isUsingBiometrics: Bool, isDonation: Bool = false) {
         self.amount = amount
         self.feeAmount = fee
         self.feeType = feeType
@@ -28,7 +28,7 @@ class ConfirmationViewController : UIViewController, ContentBoxPresenter {
     private let amount: Satoshis
     private let feeAmount: Satoshis
     private let feeType: FeeType
-    private let state: State
+    private let state: ReduxState
     private let selectedRate: Rate?
     private let minimumFractionDigits: Int?
     private let addressText: String

--- a/loafwallet/src/ViewModels/Amount.swift
+++ b/loafwallet/src/ViewModels/Amount.swift
@@ -97,7 +97,7 @@ struct Amount {
 
 struct DisplayAmount {
     let amount: Satoshis
-    let state: State
+    let state: ReduxState
     let selectedRate: Rate?
     let minimumFractionDigits: Int?
 

--- a/loafwalletTests/Legacy BRTests/TouchIdEnabledTests.swift
+++ b/loafwalletTests/Legacy BRTests/TouchIdEnabledTests.swift
@@ -25,11 +25,11 @@ class TouchIdEnabledTests : XCTestCase {
 
     func testInitialState() {
         UserDefaults.isBiometricsEnabled = true
-        let state = State.initial
+        let state = ReduxState.initial
         XCTAssertTrue(state.isBiometricsEnabled, "Initial state should be same as stored value")
 
         UserDefaults.isBiometricsEnabled = false
-        let state2 = State.initial
+        let state2 = ReduxState.initial
         XCTAssertFalse(state2.isBiometricsEnabled, "Initial state should be same as stored value")
     }
 


### PR DESCRIPTION
## Problem
 The original design of Breadwallet (Loafwallet) used a SimpleRedux architecture which maanged the State in an unsual (yet effective) way.

Within that design ‘state’ was managed by an enum named “State”

This was fine until SwiftUI and Combine where there is now a name collision since @State is referring to the SwfitUI attribute.

 ## Approach
While redesiging the app would be ideal, the reality is this needs to be fixed as soon as possible because Litewallet is now using SwiftUI.

 Steps to fix the problem:
 - [ ] Renamed variable from `State` to `ReduxState`