### PR TITLE
[Tech Debt] Remove recent LTC Price

### DIFF
--- a/loafwallet.xcodeproj/project.pbxproj
+++ b/loafwallet.xcodeproj/project.pbxproj
@@ -268,7 +268,7 @@
 		75C735AA1DAA1B9C00251ECF /* libunbound.c in Sources */ = {isa = PBXBuildFile; fileRef = 755CD4121DAA0E3E0075898E /* libunbound.c */; };
 		92FB6A24C5F95B5239A226B4 /* Pods_loafwalletTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AC86E61BB430C1275F605F8 /* Pods_loafwalletTests.framework */; };
 		BC40800031AC198047C76D8C /* Pods_loafwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D69FD9757DAE828E1DB3DC2D /* Pods_loafwallet.framework */; };
-		C30AFB4E2598FC1B00CDCF69 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */; };
+		C30AFB4E2598FC1B00CDCF69 /* LitewalletPartnerAPI in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */; };
 		C30AFB642598FFB200CDCF69 /* PartnerAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30AFB632598FFB200CDCF69 /* PartnerAPIManager.swift */; };
 		C3270B99259BF7F20073DA7B /* LitecoinCardUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3270B98259BF7F20073DA7B /* LitecoinCardUser.swift */; };
 		C32DAE0725925B7E003FC978 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32DAE0625925B7E003FC978 /* Color+Extension.swift */; };
@@ -285,8 +285,8 @@
 		C35ABD232574070A002BB9BB /* PartnersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35ABD222574070A002BB9BB /* PartnersView.swift */; };
 		C35ABD332574073F002BB9BB /* PartnersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35ABD322574073F002BB9BB /* PartnersViewModel.swift */; };
 		C379F228259B9BF000B25883 /* RegistrationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C379F227259B9BF000B25883 /* RegistrationAlertView.swift */; };
-		C38345F725B3393E00E065FD /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F625B3393E00E065FD /* SwiftPackageProductDependency */; };
-		C38345F925B3393E00E065FD /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F825B3393E00E065FD /* SwiftPackageProductDependency */; };
+		C38345F725B3393E00E065FD /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F625B3393E00E065FD /* FirebaseAnalytics */; };
+		C38345F925B3393E00E065FD /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F825B3393E00E065FD /* FirebaseCrashlytics */; };
 		C3A4647D259A646A00D74D81 /* DataValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A4647C259A646A00D74D81 /* DataValidation.swift */; };
 		C3B7C3B9255EABBF00E98A64 /* SupportSafariViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B7C3B8255EABBF00E98A64 /* SupportSafariViewModel.swift */; };
 		C3B7C3C2255EAF1200E98A64 /* SupportSafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B7C3C1255EAF1200E98A64 /* SupportSafariView.swift */; };
@@ -1703,10 +1703,10 @@
 				22A9A9621DF61FE0000F0016 /* SystemConfiguration.framework in Frameworks */,
 				22A9A9601DF61FD8000F0016 /* CoreLocation.framework in Frameworks */,
 				22A9A95E1DF61FD0000F0016 /* PushKit.framework in Frameworks */,
-				C38345F725B3393E00E065FD /* BuildFile in Frameworks */,
+				C38345F725B3393E00E065FD /* FirebaseAnalytics in Frameworks */,
 				223DB21B1DF69F0F0076A151 /* libbz2.framework in Frameworks */,
-				C30AFB4E2598FC1B00CDCF69 /* BuildFile in Frameworks */,
-				C38345F925B3393E00E065FD /* BuildFile in Frameworks */,
+				C30AFB4E2598FC1B00CDCF69 /* LitewalletPartnerAPI in Frameworks */,
+				C38345F925B3393E00E065FD /* FirebaseCrashlytics in Frameworks */,
 				752FB04D1DF8BF4B009086FB /* sqlite3.framework in Frameworks */,
 				759DA0BE1DAC36A3008CC49B /* libBRCore.a in Frameworks */,
 				BC40800031AC198047C76D8C /* Pods_loafwallet.framework in Frameworks */,
@@ -3656,9 +3656,9 @@
 			);
 			name = loafwallet;
 			packageProductDependencies = (
-				C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */,
-				C38345F625B3393E00E065FD /* SwiftPackageProductDependency */,
-				C38345F825B3393E00E065FD /* SwiftPackageProductDependency */,
+				C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */,
+				C38345F625B3393E00E065FD /* FirebaseAnalytics */,
+				C38345F825B3393E00E065FD /* FirebaseCrashlytics */,
 			);
 			productName = breadwallet;
 			productReference = 75A2A7901DA5934300A983D8 /* Litewallet.app */;
@@ -3790,8 +3790,8 @@
 			);
 			mainGroup = 75A2A7871DA5934300A983D8;
 			packageReferences = (
-				C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */,
-				C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */,
+				C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */,
+				C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			productRefGroup = 75A2A7911DA5934300A983D8 /* Products */;
 			projectDirPath = "";
@@ -5098,10 +5098,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				"OTHER_LDFLAGS[arch=*]" = (
-					"-ObjC",
-					" ",
-				);
+				"OTHER_LDFLAGS[arch=*]" = "-ObjC  ";
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_INCLUDE_PATHS = "$(SDK_DIR)/usr/include $(SRCROOT)/Modules $(SRCROOT)/loafwallet/src/Platform";
@@ -5516,15 +5513,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */ = {
+		C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/litecoin-foundation/LitewalletPartnerAPI.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.5.0;
 			};
 		};
-		C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */ = {
+		C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
@@ -5535,19 +5532,19 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */ = {
+		C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */;
+			package = C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */;
 			productName = LitewalletPartnerAPI;
 		};
-		C38345F625B3393E00E065FD /* SwiftPackageProductDependency */ = {
+		C38345F625B3393E00E065FD /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */;
+			package = C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseAnalytics;
 		};
-		C38345F825B3393E00E065FD /* SwiftPackageProductDependency */ = {
+		C38345F825B3393E00E065FD /* FirebaseCrashlytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */;
+			package = C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/loafwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/loafwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/litecoin-foundation/LitewalletPartnerAPI.git",
         "state": {
           "branch": null,
-          "revision": "3dc7a74f5c4a3dd054b5eaacfe68909e68e99766",
-          "version": "0.3.0"
+          "revision": "5fafe40f4eac370440d39192d73916a387b0f36e",
+          "version": "0.5.0"
         }
       },
       {

--- a/loafwallet/Storyboards/Main.storyboard
+++ b/loafwallet/Storyboards/Main.storyboard
@@ -63,32 +63,10 @@
                                             <action selector="showSettingsAction:" destination="x3n-5i-KbR" eventType="touchUpInside" id="34N-aU-I4A"/>
                                         </connections>
                                     </button>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="bottom" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="RAg-vc-Wor">
-                                        <rect key="frame" x="331.33333333333331" y="12" width="38.666666666666686" height="36"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dET-GI-JeX">
-                                                <rect key="frame" x="0.0" y="0.0" width="38.666666666666664" height="21.666666666666668"/>
-                                                <fontDescription key="fontDescription" name="BarlowSemiCondensed-Medium" family="Barlow Semi Condensed Medium" pointSize="18"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eVZ-9F-hgM">
-                                                <rect key="frame" x="15.666666666666686" y="22.666666666666664" width="23" height="13.333333333333336"/>
-                                                <fontDescription key="fontDescription" name="BarlowSemiCondensed-Light" family="Barlow Semi Condensed Light" pointSize="11"/>
-                                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
-                                        </subviews>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="36" id="M3y-Ln-jGL"/>
-                                        </constraints>
-                                    </stackView>
                                 </subviews>
                                 <viewLayoutGuide key="safeArea" id="81g-U6-NOG"/>
                                 <color key="backgroundColor" systemColor="systemPinkColor"/>
                                 <constraints>
-                                    <constraint firstItem="zmH-Ee-H6k" firstAttribute="leading" secondItem="RAg-vc-Wor" secondAttribute="trailing" constant="10" id="LKm-Ws-j91"/>
-                                    <constraint firstItem="RAg-vc-Wor" firstAttribute="centerY" secondItem="ZHZ-G5-6k8" secondAttribute="centerY" id="huE-hU-1KP"/>
                                     <constraint firstAttribute="height" constant="60" id="iBk-qu-OG6"/>
                                     <constraint firstItem="zmH-Ee-H6k" firstAttribute="centerY" secondItem="ZHZ-G5-6k8" secondAttribute="centerY" id="ksC-fB-keg"/>
                                     <constraint firstAttribute="trailing" secondItem="zmH-Ee-H6k" secondAttribute="trailing" constant="10" id="vY4-OJ-KBs"/>
@@ -122,13 +100,9 @@
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="containerView" destination="euD-bi-teC" id="8Hi-tB-iI4"/>
-                        <outlet property="currentLTCPriceLabel" destination="dET-GI-JeX" id="6nV-rL-53D"/>
                         <outlet property="headerView" destination="ZHZ-G5-6k8" id="eca-ki-lm4"/>
                         <outlet property="settingsButton" destination="zmH-Ee-H6k" id="k3e-rQ-MBP"/>
                         <outlet property="tabBar" destination="j3Z-Gw-zod" id="PpH-h0-AQX"/>
-                        <outlet property="timeStampLabel" destination="eVZ-9F-hgM" id="s8z-9v-5Gc"/>
-                        <outlet property="timeStampStackView" destination="RAg-vc-Wor" id="mfo-7A-ayM"/>
-                        <outlet property="timeStampStackViewHeight" destination="M3y-Ln-jGL" id="aUv-Zm-IFf"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="2Bt-6z-wZV" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/loafwallet/TabBarViewController.swift
+++ b/loafwallet/TabBarViewController.swift
@@ -21,12 +21,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
     @IBOutlet weak var headerView: UIView!
     @IBOutlet weak var containerView: UIView!
     @IBOutlet weak var tabBar: UITabBar!
-    @IBOutlet weak var currentLTCPriceLabel: UILabel!
-    @IBOutlet weak var settingsButton: UIButton!
-    @IBOutlet weak var timeStampLabel: UILabel!
-    @IBOutlet weak var timeStampStackView: UIStackView!
-    @IBOutlet weak var timeStampStackViewHeight: NSLayoutConstraint!
-     
+    @IBOutlet weak var settingsButton: UIButton!  
     var primaryBalanceLabel: UpdatingLabel?
     var secondaryBalanceLabel: UpdatingLabel?
     private let largeFontSize: CGFloat = 24.0
@@ -140,7 +135,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         equalsLabel.translatesAutoresizingMaskIntoConstraints = false
         primaryLabel.translatesAutoresizingMaskIntoConstraints = false
         regularConstraints = [
-            primaryLabel.firstBaselineAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -12),
+            primaryLabel.firstBaselineAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -20),
             primaryLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: C.padding[1]*1.25),
             equalsLabel.firstBaselineAnchor.constraint(equalTo: primaryLabel.firstBaselineAnchor, constant: 0),
             equalsLabel.leadingAnchor.constraint(equalTo: primaryLabel.trailingAnchor, constant: C.padding[1]/2.0),
@@ -148,7 +143,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         ]
         
         swappedConstraints = [
-            secondaryLabel.firstBaselineAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -12),
+            secondaryLabel.firstBaselineAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -20),
             secondaryLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: C.padding[1]*1.25),
             equalsLabel.firstBaselineAnchor.constraint(equalTo: secondaryLabel.firstBaselineAnchor, constant: 0),
             equalsLabel.leadingAnchor.constraint(equalTo: secondaryLabel.trailingAnchor, constant: C.padding[1]/2.0),
@@ -159,14 +154,14 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
             NSLayoutConstraint.activate(isLTCSwapped ? self.swappedConstraints : self.regularConstraints)
         }
         
-        currencyTapView.constrain([
-                                    currencyTapView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 0),
-                                    currencyTapView.trailingAnchor.constraint(equalTo: self.timeStampStackView.leadingAnchor, constant: 0),
-                                    currencyTapView.topAnchor.constraint(equalTo: primaryLabel.topAnchor, constant: 0),
-                                    currencyTapView.bottomAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: C.padding[1]) ])
-        
-        let gr = UITapGestureRecognizer(target: self, action: #selector(currencySwitchTapped))
-        currencyTapView.addGestureRecognizer(gr)
+        currencyTapView.constrain([ 
+                   currencyTapView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 0),
+                   currencyTapView.trailingAnchor.constraint(equalTo: self.settingsButton.leadingAnchor, constant: 0),
+                   currencyTapView.topAnchor.constraint(equalTo: primaryLabel.topAnchor, constant: 0),
+                   currencyTapView.bottomAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: C.padding[1]) ])
+
+         let gr = UITapGestureRecognizer(target: self, action: #selector(currencySwitchTapped))
+         currencyTapView.addGestureRecognizer(gr) 
     }
     //MARK: - Adding Subscriptions
     private func addSubscriptions() {
@@ -266,14 +261,8 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         } else {
             secondaryLabel.transform = .identity
             primaryLabel.transform = transform(forView: primaryLabel)
-        }
-        
-        self.timeStampLabel.text = S.TransactionDetails.priceTimeStampLabel + " " + dateFormatter.string(from: Date())
-        let fiatRate = Double(round(100*rate.rate)/100)
-        let formattedFiatString = String(format: "%.02f", fiatRate)
-        self.currentLTCPriceLabel.text = Currency.getSymbolForCurrencyCode(code: rate.code)! + formattedFiatString
-        
-    }
+        } 
+     }
     
     private func transform(forView: UIView) ->  CGAffineTransform {
         forView.transform = .identity //Must reset the view's transform before we calculate the next transform


### PR DESCRIPTION
## Issue
There have been a few customer support tickets where users mistake the recent price with their balance.  This is a serious issue.

## Rationale for the change
Since we have an increasing number of users and we cannot burden them we need to remove any doubt. Especially with the new users of Litewallet

**Pros of removal**: 
- Android doesn't have the price change label
- No confusion
- The fix is trivial (0.5 points)

**Cons of removal**:
- It's purty


## Commits
- adjusted labels and removed price

## Screenshots
Before | After
-------|------
![with-price](https://user-images.githubusercontent.com/2899463/105559260-94a69a00-5d08-11eb-9a8a-33262a1c1f16.gif)|![no-price](https://user-images.githubusercontent.com/2899463/105559268-9a9c7b00-5d08-11eb-810f-079cd31d2cfe.gif)

