### PR TITLE
[Feature] Unhide Litecoin card prod v1

### DIFF
--- a/loafwallet.xcodeproj/project.pbxproj
+++ b/loafwallet.xcodeproj/project.pbxproj
@@ -132,7 +132,6 @@
 		24D5F26F225A5BEA00225462 /* ContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D5F26D225A5BEA00225462 /* ContainerViewController.swift */; };
 		24D91D0B2166923E0077A619 /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24D91D0A2166923E0077A619 /* UserNotifications.framework */; };
 		24DFCE6823B89CDE001F17F8 /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 24DFCE6723B89CDE001F17F8 /* Settings.storyboard */; };
-		74B3E4C4DD12414DD0484B2F /* Pods_loafwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDAC39ACED69AB0E4CAAEE32 /* Pods_loafwallet.framework */; };
 		7503773D1DF57428005EB8AE /* WalletManager+Auth.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7503773C1DF57428005EB8AE /* WalletManager+Auth.swift */; };
 		751734B91DAC941E00193C87 /* sec-sub-1.c in Sources */ = {isa = PBXBuildFile; fileRef = 755CD8BE1DAA16820075898E /* sec-sub-1.c */; };
 		752438751DAAC50800844BEC /* alloc.c in Sources */ = {isa = PBXBuildFile; fileRef = 755CD6761DAA0E400075898E /* alloc.c */; };
@@ -267,8 +266,9 @@
 		75A2A8101DA5936F00A983D8 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 75A2A80E1DA5936F00A983D8 /* MainInterface.storyboard */; };
 		75A2A8141DA5936F00A983D8 /* TodayExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 75A2A8081DA5936F00A983D8 /* TodayExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		75C735AA1DAA1B9C00251ECF /* libunbound.c in Sources */ = {isa = PBXBuildFile; fileRef = 755CD4121DAA0E3E0075898E /* libunbound.c */; };
-		9F277AD526A9DAEC0A5F4008 /* Pods_loafwalletTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CCD0579E0855FDF49144D8A /* Pods_loafwalletTests.framework */; };
-		C30AFB4E2598FC1B00CDCF69 /* LitewalletPartnerAPI in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */; };
+		92FB6A24C5F95B5239A226B4 /* Pods_loafwalletTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9AC86E61BB430C1275F605F8 /* Pods_loafwalletTests.framework */; };
+		BC40800031AC198047C76D8C /* Pods_loafwallet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D69FD9757DAE828E1DB3DC2D /* Pods_loafwallet.framework */; };
+		C30AFB4E2598FC1B00CDCF69 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */; };
 		C30AFB642598FFB200CDCF69 /* PartnerAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30AFB632598FFB200CDCF69 /* PartnerAPIManager.swift */; };
 		C3270B99259BF7F20073DA7B /* LitecoinCardUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3270B98259BF7F20073DA7B /* LitecoinCardUser.swift */; };
 		C32DAE0725925B7E003FC978 /* Color+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32DAE0625925B7E003FC978 /* Color+Extension.swift */; };
@@ -285,8 +285,8 @@
 		C35ABD232574070A002BB9BB /* PartnersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35ABD222574070A002BB9BB /* PartnersView.swift */; };
 		C35ABD332574073F002BB9BB /* PartnersViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35ABD322574073F002BB9BB /* PartnersViewModel.swift */; };
 		C379F228259B9BF000B25883 /* RegistrationAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C379F227259B9BF000B25883 /* RegistrationAlertView.swift */; };
-		C38345F725B3393E00E065FD /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F625B3393E00E065FD /* FirebaseAnalytics */; };
-		C38345F925B3393E00E065FD /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F825B3393E00E065FD /* FirebaseCrashlytics */; };
+		C38345F725B3393E00E065FD /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F625B3393E00E065FD /* SwiftPackageProductDependency */; };
+		C38345F925B3393E00E065FD /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C38345F825B3393E00E065FD /* SwiftPackageProductDependency */; };
 		C3A4647D259A646A00D74D81 /* DataValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3A4647C259A646A00D74D81 /* DataValidation.swift */; };
 		C3B7C3B9255EABBF00E98A64 /* SupportSafariViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B7C3B8255EABBF00E98A64 /* SupportSafariViewModel.swift */; };
 		C3B7C3C2255EAF1200E98A64 /* SupportSafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B7C3C1255EAF1200E98A64 /* SupportSafariView.swift */; };
@@ -574,7 +574,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		140FA787B8C189CDA7E8EA0A /* Pods-loafwalletTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.release.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.release.xcconfig"; sourceTree = "<group>"; };
 		1B3F74211FFB106200CCA50C /* BiometricsSettingsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BiometricsSettingsViewController.swift; path = src/ViewControllers/BiometricsSettingsViewController.swift; sourceTree = "<group>"; };
 		1B3F74221FFB106200CCA50C /* BiometricsSpendingLimitViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = BiometricsSpendingLimitViewController.swift; path = src/ViewControllers/BiometricsSpendingLimitViewController.swift; sourceTree = "<group>"; };
 		1BA74B85206AD60A0083BD2A /* Fabric.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Fabric.framework; sourceTree = "<group>"; };
@@ -837,7 +836,8 @@
 		24D91D0A2166923E0077A619 /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		24D91D0D2166A5480077A619 /* TestnetData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestnetData.swift; sourceTree = "<group>"; };
 		24DFCE6723B89CDE001F17F8 /* Settings.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
-		2CCD0579E0855FDF49144D8A /* Pods_loafwalletTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_loafwalletTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6008481CC5B78F1CF8F9EA57 /* Pods-loafwallet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.debug.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.debug.xcconfig"; sourceTree = "<group>"; };
+		65B44EBCC7D4AFCDB8B91F8A /* Pods-loafwalletTests.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.testnet.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.testnet.xcconfig"; sourceTree = "<group>"; };
 		7503773C1DF57428005EB8AE /* WalletManager+Auth.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "WalletManager+Auth.swift"; path = "src/WalletManager+Auth.swift"; sourceTree = "<group>"; };
 		7528D2971ECF655500925DBC /* PaymentProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = PaymentProtocol.swift; path = src/PaymentProtocol.swift; sourceTree = "<group>"; };
 		752FB03B1DF8BE4B009086FB /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -1437,8 +1437,10 @@
 		75A2A87C1DA59E4E00A983D8 /* loafwallet.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = loafwallet.entitlements; sourceTree = "<group>"; };
 		75C735AF1DAA1C9F00251ECF /* libnettle.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libnettle.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		75FEFD1B1DAED56E00203D3A /* libsqlite3.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libsqlite3.tbd; path = usr/lib/libsqlite3.tbd; sourceTree = SDKROOT; };
-		80008B6D966315A287287C5F /* Pods-loafwalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.debug.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.debug.xcconfig"; sourceTree = "<group>"; };
-		82B54D9BA6CCD590F3B15E32 /* Pods-loafwallet.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.testnet.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.testnet.xcconfig"; sourceTree = "<group>"; };
+		96694FA018937A83E970CC55 /* Pods-loafwalletTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.release.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.release.xcconfig"; sourceTree = "<group>"; };
+		9AC86E61BB430C1275F605F8 /* Pods_loafwalletTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_loafwalletTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A3E5444354AB8914A966CDC2 /* Pods-loafwallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.release.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.release.xcconfig"; sourceTree = "<group>"; };
+		B1E980ED11476D536096EFFC /* Pods-loafwallet.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.testnet.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.testnet.xcconfig"; sourceTree = "<group>"; };
 		C30AFB632598FFB200CDCF69 /* PartnerAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartnerAPIManager.swift; sourceTree = "<group>"; };
 		C3270B98259BF7F20073DA7B /* LitecoinCardUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LitecoinCardUser.swift; sourceTree = "<group>"; };
 		C32DAE0625925B7E003FC978 /* Color+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Extension.swift"; sourceTree = "<group>"; };
@@ -1648,10 +1650,8 @@
 		CEF61B111ECF52C700C7EA6A /* AmountViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; name = AmountViewController.swift; path = src/ViewControllers/AmountViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		CEF61B131ED0D10000C7EA6A /* Types.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Types.swift; path = src/Models/Types.swift; sourceTree = "<group>"; };
 		CEF61B151ED2056D00C7EA6A /* NumberFormatter+Additions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NumberFormatter+Additions.swift"; path = "src/Extensions/NumberFormatter+Additions.swift"; sourceTree = "<group>"; };
-		D65EC4117578A5C9BA040F8D /* Pods-loafwalletTests.testnet.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.testnet.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.testnet.xcconfig"; sourceTree = "<group>"; };
-		DDAC39ACED69AB0E4CAAEE32 /* Pods_loafwallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_loafwallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		E4CCF28E98A07DAA4910FCA8 /* Pods-loafwallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.release.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.release.xcconfig"; sourceTree = "<group>"; };
-		F2DC7DD25C905C64E479CE86 /* Pods-loafwallet.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.debug.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.debug.xcconfig"; sourceTree = "<group>"; };
+		D25607DBC5E9F06B12996E3E /* Pods-loafwalletTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwalletTests.debug.xcconfig"; path = "Target Support Files/Pods-loafwalletTests/Pods-loafwalletTests.debug.xcconfig"; sourceTree = "<group>"; };
+		D69FD9757DAE828E1DB3DC2D /* Pods_loafwallet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_loafwallet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1667,7 +1667,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				9F277AD526A9DAEC0A5F4008 /* Pods_loafwalletTests.framework in Frameworks */,
+				92FB6A24C5F95B5239A226B4 /* Pods_loafwalletTests.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1703,13 +1703,13 @@
 				22A9A9621DF61FE0000F0016 /* SystemConfiguration.framework in Frameworks */,
 				22A9A9601DF61FD8000F0016 /* CoreLocation.framework in Frameworks */,
 				22A9A95E1DF61FD0000F0016 /* PushKit.framework in Frameworks */,
-				C38345F725B3393E00E065FD /* FirebaseAnalytics in Frameworks */,
+				C38345F725B3393E00E065FD /* BuildFile in Frameworks */,
 				223DB21B1DF69F0F0076A151 /* libbz2.framework in Frameworks */,
-				C30AFB4E2598FC1B00CDCF69 /* LitewalletPartnerAPI in Frameworks */,
-				C38345F925B3393E00E065FD /* FirebaseCrashlytics in Frameworks */,
+				C30AFB4E2598FC1B00CDCF69 /* BuildFile in Frameworks */,
+				C38345F925B3393E00E065FD /* BuildFile in Frameworks */,
 				752FB04D1DF8BF4B009086FB /* sqlite3.framework in Frameworks */,
 				759DA0BE1DAC36A3008CC49B /* libBRCore.a in Frameworks */,
-				74B3E4C4DD12414DD0484B2F /* Pods_loafwallet.framework in Frameworks */,
+				BC40800031AC198047C76D8C /* Pods_loafwallet.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3027,8 +3027,8 @@
 				75FEFD1B1DAED56E00203D3A /* libsqlite3.tbd */,
 				75A2A7F21DA5935F00A983D8 /* Messages.framework */,
 				75A2A8091DA5936F00A983D8 /* NotificationCenter.framework */,
-				DDAC39ACED69AB0E4CAAEE32 /* Pods_loafwallet.framework */,
-				2CCD0579E0855FDF49144D8A /* Pods_loafwalletTests.framework */,
+				D69FD9757DAE828E1DB3DC2D /* Pods_loafwallet.framework */,
+				9AC86E61BB430C1275F605F8 /* Pods_loafwalletTests.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -3492,12 +3492,12 @@
 		FEE036865998B9DFEEF3139A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				F2DC7DD25C905C64E479CE86 /* Pods-loafwallet.debug.xcconfig */,
-				82B54D9BA6CCD590F3B15E32 /* Pods-loafwallet.testnet.xcconfig */,
-				E4CCF28E98A07DAA4910FCA8 /* Pods-loafwallet.release.xcconfig */,
-				80008B6D966315A287287C5F /* Pods-loafwalletTests.debug.xcconfig */,
-				D65EC4117578A5C9BA040F8D /* Pods-loafwalletTests.testnet.xcconfig */,
-				140FA787B8C189CDA7E8EA0A /* Pods-loafwalletTests.release.xcconfig */,
+				6008481CC5B78F1CF8F9EA57 /* Pods-loafwallet.debug.xcconfig */,
+				B1E980ED11476D536096EFFC /* Pods-loafwallet.testnet.xcconfig */,
+				A3E5444354AB8914A966CDC2 /* Pods-loafwallet.release.xcconfig */,
+				D25607DBC5E9F06B12996E3E /* Pods-loafwalletTests.debug.xcconfig */,
+				65B44EBCC7D4AFCDB8B91F8A /* Pods-loafwalletTests.testnet.xcconfig */,
+				96694FA018937A83E970CC55 /* Pods-loafwalletTests.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -3561,7 +3561,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2465873D23A5AAD100A32E9E /* Build configuration list for PBXNativeTarget "loafwalletTests" */;
 			buildPhases = (
-				C181B998505AF9F669EA21C4 /* [CP] Check Pods Manifest.lock */,
+				5723028C3694917363D260E0 /* [CP] Check Pods Manifest.lock */,
 				2465873223A5AAD000A32E9E /* Sources */,
 				2465873323A5AAD000A32E9E /* Frameworks */,
 				2465873423A5AAD000A32E9E /* Resources */,
@@ -3634,7 +3634,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 75A2A7E31DA5934400A983D8 /* Build configuration list for PBXNativeTarget "loafwallet" */;
 			buildPhases = (
-				95A0AE4B0D23BB143F8D11D7 /* [CP] Check Pods Manifest.lock */,
+				832DFB05CE15FD50F6854519 /* [CP] Check Pods Manifest.lock */,
 				2430679A238F538C00EBEA99 /* Update Localizable using BartyCrouch */,
 				24E179F223BDAF8000F928D9 /* Xcode custom warnings */,
 				75A2A78C1DA5934300A983D8 /* Sources */,
@@ -3643,8 +3643,8 @@
 				75A2A8031DA5935F00A983D8 /* Embed App Extensions */,
 				22A9A9831DF63288000F0016 /* Embed Frameworks */,
 				C3D1588125666B69009BD3BC /* Mark Dev Notes */,
-				C38056DB231D707AAC9C4808 /* [CP] Embed Pods Frameworks */,
 				C383465325B34D8F00E065FD /* Upload dSYMs to Firebase */,
+				0A6FE96D6D66CEA3039B3345 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -3656,9 +3656,9 @@
 			);
 			name = loafwallet;
 			packageProductDependencies = (
-				C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */,
-				C38345F625B3393E00E065FD /* FirebaseAnalytics */,
-				C38345F825B3393E00E065FD /* FirebaseCrashlytics */,
+				C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */,
+				C38345F625B3393E00E065FD /* SwiftPackageProductDependency */,
+				C38345F825B3393E00E065FD /* SwiftPackageProductDependency */,
 			);
 			productName = breadwallet;
 			productReference = 75A2A7901DA5934300A983D8 /* Litewallet.app */;
@@ -3790,8 +3790,8 @@
 			);
 			mainGroup = 75A2A7871DA5934300A983D8;
 			packageReferences = (
-				C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */,
-				C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */,
+				C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */,
 			);
 			productRefGroup = 75A2A7911DA5934300A983D8 /* Products */;
 			projectDirPath = "";
@@ -3882,6 +3882,23 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
+		0A6FE96D6D66CEA3039B3345 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
 		2430679A238F538C00EBEA99 /* Update Localizable using BartyCrouch */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 12;
@@ -3914,29 +3931,7 @@
 			shellPath = /bin/sh;
 			shellScript = "TAGS=\"TODO:|FIXME:|WARNING:\"\nfind \"${SRCROOT}\" \\( -name \"*.h\" -or -name \"*.m\" -or -name \"*.swift\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($TAGS).*\\$\" | perl -p -e \"s/($TAGS)/ warning: \\$1/\"\n";
 		};
-		95A0AE4B0D23BB143F8D11D7 /* [CP] Check Pods Manifest.lock */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
-				"${PODS_ROOT}/Manifest.lock",
-			);
-			name = "[CP] Check Pods Manifest.lock";
-			outputFileListPaths = (
-			);
-			outputPaths = (
-				"$(DERIVED_FILE_DIR)/Pods-loafwallet-checkManifestLockResult.txt",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		C181B998505AF9F669EA21C4 /* [CP] Check Pods Manifest.lock */ = {
+		5723028C3694917363D260E0 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -3958,21 +3953,26 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		C38056DB231D707AAC9C4808 /* [CP] Embed Pods Frameworks */ = {
+		832DFB05CE15FD50F6854519 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
-			name = "[CP] Embed Pods Frameworks";
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
 			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-loafwallet-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-loafwallet/Pods-loafwallet-frameworks.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 		C383465325B34D8F00E065FD /* Upload dSYMs to Firebase */ = {
@@ -4686,7 +4686,7 @@
 				SWIFT_INCLUDE_PATHS = "$(SDK_DIR)/usr/include $(SRCROOT)/Modules $(SRCROOT)/loafwallet/src/Platform";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -4694,7 +4694,7 @@
 		};
 		24470E0123A5BF3C00ADDA27 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = F2DC7DD25C905C64E479CE86 /* Pods-loafwallet.debug.xcconfig */;
+			baseConfigurationReference = 6008481CC5B78F1CF8F9EA57 /* Pods-loafwallet.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -4727,7 +4727,7 @@
 		};
 		24470E0323A5BF3C00ADDA27 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 80008B6D966315A287287C5F /* Pods-loafwalletTests.debug.xcconfig */;
+			baseConfigurationReference = D25607DBC5E9F06B12996E3E /* Pods-loafwalletTests.debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				BUNDLE_LOADER = "$(TEST_HOST)";
@@ -4935,7 +4935,7 @@
 		};
 		2465873F23A5AAD100A32E9E /* Testnet */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = D65EC4117578A5C9BA040F8D /* Pods-loafwalletTests.testnet.xcconfig */;
+			baseConfigurationReference = 65B44EBCC7D4AFCDB8B91F8A /* Pods-loafwalletTests.testnet.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -4963,7 +4963,7 @@
 		};
 		2465874023A5AAD100A32E9E /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 140FA787B8C189CDA7E8EA0A /* Pods-loafwalletTests.release.xcconfig */;
+			baseConfigurationReference = 96694FA018937A83E970CC55 /* Pods-loafwalletTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
@@ -5098,13 +5098,16 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
-				"OTHER_LDFLAGS[arch=*]" = "-ObjC ";
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-ObjC",
+					" ",
+				);
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_INCLUDE_PATHS = "$(SDK_DIR)/usr/include $(SRCROOT)/Modules $(SRCROOT)/loafwallet/src/Platform";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
@@ -5112,7 +5115,7 @@
 		};
 		75A2A7E51DA5934400A983D8 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = E4CCF28E98A07DAA4910FCA8 /* Pods-loafwallet.release.xcconfig */;
+			baseConfigurationReference = A3E5444354AB8914A966CDC2 /* Pods-loafwallet.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -5235,14 +5238,14 @@
 				SWIFT_INCLUDE_PATHS = "$(SDK_DIR)/usr/include $(SRCROOT)/Modules $(SRCROOT)/loafwallet/src/Platform";
 				SWIFT_INSTALL_OBJC_HEADER = NO;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Testnet;
 		};
 		CEA7E69C1F0AAA84001F8C27 /* Testnet */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 82B54D9BA6CCD590F3B15E32 /* Pods-loafwallet.testnet.xcconfig */;
+			baseConfigurationReference = B1E980ED11476D536096EFFC /* Pods-loafwallet.testnet.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -5513,7 +5516,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */ = {
+		C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/litecoin-foundation/LitewalletPartnerAPI.git";
 			requirement = {
@@ -5521,7 +5524,7 @@
 				minimumVersion = 0.2.0;
 			};
 		};
-		C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+		C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk.git";
 			requirement = {
@@ -5532,19 +5535,19 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */ = {
+		C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C30AFB4C2598FC1B00CDCF69 /* XCRemoteSwiftPackageReference "LitewalletPartnerAPI" */;
+			package = C30AFB4C2598FC1B00CDCF69 /* RemoteSwiftPackageReference */;
 			productName = LitewalletPartnerAPI;
 		};
-		C38345F625B3393E00E065FD /* FirebaseAnalytics */ = {
+		C38345F625B3393E00E065FD /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */;
 			productName = FirebaseAnalytics;
 		};
-		C38345F825B3393E00E065FD /* FirebaseCrashlytics */ = {
+		C38345F825B3393E00E065FD /* SwiftPackageProductDependency */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = C38345F525B3393E00E065FD /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			package = C38345F525B3393E00E065FD /* RemoteSwiftPackageReference */;
 			productName = FirebaseCrashlytics;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/loafwallet/Storyboards/Main.storyboard
+++ b/loafwallet/Storyboards/Main.storyboard
@@ -33,14 +33,15 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tabBar contentMode="redraw" translucent="NO" translatesAutoresizingMaskIntoConstraints="NO" id="j3Z-Gw-zod">
-                                <rect key="frame" x="0.0" y="638" width="414" height="49"/>
+                                <rect key="frame" x="0.0" y="589" width="414" height="98"/>
                                 <viewLayoutGuide key="safeArea" id="TzC-tl-jAG"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <items>
                                     <tabBarItem title="History" image="history_icon" selectedImage="history_icon" id="qwA-9l-CfE" userLabel="History"/>
                                     <tabBarItem tag="1" title="Send" image="send_icon" selectedImage="send_icon" id="Idu-CT-kfl" userLabel="Send"/>
-                                    <tabBarItem tag="2" title="Receive" image="receive_icon" selectedImage="receive_icon" id="1Ar-eJ-M87" userLabel="Receive"/>
-                                    <tabBarItem tag="3" title="Buy" image="litecoin_cutout24" selectedImage="litecoin_cutout24" id="spP-38-fzY" userLabel="Buy"/>
+                                    <tabBarItem tag="2" title="Item" image="card_icon" selectedImage="card_icon" id="DPD-tH-DDL" userLabel="Card"/>
+                                    <tabBarItem tag="3" title="Receive" image="receive_icon" selectedImage="receive_icon" id="1Ar-eJ-M87" userLabel="Receive"/>
+                                    <tabBarItem tag="4" title="Buy" image="litecoin_cutout24" selectedImage="litecoin_cutout24" id="spP-38-fzY" userLabel="Buy"/>
                                 </items>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <connections>
@@ -94,7 +95,7 @@
                                 </constraints>
                             </view>
                             <containerView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="euD-bi-teC">
-                                <rect key="frame" x="0.0" y="60" width="414" height="578"/>
+                                <rect key="frame" x="0.0" y="60" width="414" height="529"/>
                                 <viewLayoutGuide key="safeArea" id="spi-yc-QnP"/>
                                 <connections>
                                     <segue destination="0H7-tx-uMf" kind="embed" id="RDN-fw-P5V"/>
@@ -139,7 +140,7 @@
             <objects>
                 <viewController id="0H7-tx-uMf" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="z4T-ui-Ve5">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="578"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="529"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="UuX-cb-qOU"/>
                         <color key="backgroundColor" red="0.20539733769999999" green="0.36322331429999999" blue="0.61663442850000005" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -367,6 +368,7 @@
     </scenes>
     <resources>
         <image name="FaceId" width="24" height="24"/>
+        <image name="card_icon" width="24" height="24"/>
         <image name="coinBlueWhite" width="230" height="230"/>
         <image name="history_icon" width="32" height="32"/>
         <image name="litecoin_cutout24" width="24" height="24"/>

--- a/loafwallet/Storyboards/Main.storyboard
+++ b/loafwallet/Storyboards/Main.storyboard
@@ -39,7 +39,7 @@
                                 <items>
                                     <tabBarItem title="History" image="history_icon" selectedImage="history_icon" id="qwA-9l-CfE" userLabel="History"/>
                                     <tabBarItem tag="1" title="Send" image="send_icon" selectedImage="send_icon" id="Idu-CT-kfl" userLabel="Send"/>
-                                    <tabBarItem tag="2" title="Item" image="card_icon" selectedImage="card_icon" id="DPD-tH-DDL" userLabel="Card"/>
+                                    <tabBarItem tag="2" title="Card" image="card_icon" selectedImage="card_icon" id="DPD-tH-DDL" userLabel="Card"/>
                                     <tabBarItem tag="3" title="Receive" image="receive_icon" selectedImage="receive_icon" id="1Ar-eJ-M87" userLabel="Receive"/>
                                     <tabBarItem tag="4" title="Buy" image="litecoin_cutout24" selectedImage="litecoin_cutout24" id="spP-38-fzY" userLabel="Buy"/>
                                 </items>

--- a/loafwallet/TabBarViewController.swift
+++ b/loafwallet/TabBarViewController.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2019 Litecoin Foundation. All rights reserved.
 
 import UIKit
-import Foundation 
+import Foundation
 
 enum TabViewControllerIndex: Int {
     case transactions = 0
@@ -14,9 +14,9 @@ enum TabViewControllerIndex: Int {
     case buy = 2
     case receive = 3
 }
-  
+
 class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDelegate {
-      
+    
     let kInitialChildViewControllerIndex = 0 // TransactionsViewController
     @IBOutlet weak var headerView: UIView!
     @IBOutlet weak var containerView: UIView!
@@ -26,9 +26,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
     @IBOutlet weak var timeStampLabel: UILabel!
     @IBOutlet weak var timeStampStackView: UIStackView!
     @IBOutlet weak var timeStampStackViewHeight: NSLayoutConstraint!
-    
-    
-    
+     
     var primaryBalanceLabel: UpdatingLabel?
     var secondaryBalanceLabel: UpdatingLabel?
     private let largeFontSize: CGFloat = 24.0
@@ -40,11 +38,11 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
     private var regularConstraints: [NSLayoutConstraint] = []
     private var swappedConstraints: [NSLayoutConstraint] = []
     private let currencyTapView = UIView()
-    private let storyboardNames:[String] = ["Transactions","Send","Receive","Buy"]
-    var storyboardIDs:[String] = ["TransactionsViewController","SendLTCViewController","ReceiveLTCViewController","BuyTableViewController"]
+    private let storyboardNames:[String] = ["Transactions","Send","Card","Receive","Buy"]
+    var storyboardIDs:[String] = ["TransactionsViewController","SendLTCViewController","CardViewController","ReceiveLTCViewController","BuyTableViewController"]
     var viewControllers:[UIViewController] = []
     var activeController:UIViewController? = nil
-       
+    
     var updateTimer: Timer?
     var store: Store?
     var walletManager: WalletManager?
@@ -68,14 +66,13 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         store.perform(action: RootModalActions.Present(modal: .menu))
     }
     
-      
     override func viewDidLoad() {
         super.viewDidLoad()
         setupViews()
         configurePriceLabels()
         addSubscriptions()
         dateFormatter.setLocalizedDateFormatFromTemplate("MMM d, h:mm a")
-  
+        
         for (index, storyboardID) in self.storyboardIDs.enumerated() {
             let controller = UIStoryboard.init(name: storyboardNames[index], bundle: nil).instantiateViewController(withIdentifier: storyboardID)
             viewControllers.append(controller)
@@ -98,36 +95,36 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
     
     private func setupViews() {
         
-       if #available(iOS 11.0, *),
-            let  backgroundColor = UIColor(named: "mainColor") {
+        if #available(iOS 11.0, *),
+           let  backgroundColor = UIColor(named: "mainColor") {
             headerView.backgroundColor = backgroundColor
             tabBar.barTintColor = backgroundColor
             containerView.backgroundColor = backgroundColor
             self.view.backgroundColor = backgroundColor
-       } else {
+        } else {
             headerView.backgroundColor = .liteWalletBlue
             tabBar.barTintColor = .liteWalletBlue
             containerView.backgroundColor = .liteWalletBlue
             self.view.backgroundColor = .liteWalletBlue
-       }
+        }
     }
     
     private func configurePriceLabels() {
-
+        
         //TODO: Debug the reizing of label...very important
         guard let primaryLabel = self.primaryBalanceLabel ,
-            let secondaryLabel = self.secondaryBalanceLabel else {
-          NSLog("ERROR: Price labels not initialized")
-                return
+              let secondaryLabel = self.secondaryBalanceLabel else {
+            NSLog("ERROR: Price labels not initialized")
+            return
         }
-         
+        
         let priceLabelArray = [primaryBalanceLabel,secondaryBalanceLabel,equalsLabel]
         
         priceLabelArray.enumerated().forEach { (index, view) in
             view?.backgroundColor = .clear
             view?.textColor = .white
         }
- 
+        
         primaryLabel.font = UIFont.barlowSemiBold(size: largeFontSize)
         secondaryLabel.font = UIFont.barlowSemiBold(size: largeFontSize)
         
@@ -136,10 +133,10 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         headerView.addSubview(secondaryLabel)
         headerView.addSubview(equalsLabel)
         headerView.addSubview(currencyTapView)
- 
+        
         secondaryLabel.constrain([
-            secondaryLabel.constraint(.firstBaseline, toView: primaryLabel, constant: 0.0) ])
-
+                                    secondaryLabel.constraint(.firstBaseline, toView: primaryLabel, constant: 0.0) ])
+        
         equalsLabel.translatesAutoresizingMaskIntoConstraints = false
         primaryLabel.translatesAutoresizingMaskIntoConstraints = false
         regularConstraints = [
@@ -148,50 +145,48 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
             equalsLabel.firstBaselineAnchor.constraint(equalTo: primaryLabel.firstBaselineAnchor, constant: 0),
             equalsLabel.leadingAnchor.constraint(equalTo: primaryLabel.trailingAnchor, constant: C.padding[1]/2.0),
             secondaryLabel.leadingAnchor.constraint(equalTo: equalsLabel.trailingAnchor, constant: C.padding[1]/2.0),
-         ]
-         
+        ]
+        
         swappedConstraints = [
             secondaryLabel.firstBaselineAnchor.constraint(equalTo: headerView.bottomAnchor, constant: -12),
             secondaryLabel.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: C.padding[1]*1.25),
             equalsLabel.firstBaselineAnchor.constraint(equalTo: secondaryLabel.firstBaselineAnchor, constant: 0),
             equalsLabel.leadingAnchor.constraint(equalTo: secondaryLabel.trailingAnchor, constant: C.padding[1]/2.0),
             primaryLabel.leadingAnchor.constraint(equalTo: equalsLabel.trailingAnchor, constant: C.padding[1]/2.0),
-         ]
+        ]
         
         if let isLTCSwapped = self.isLtcSwapped {
             NSLayoutConstraint.activate(isLTCSwapped ? self.swappedConstraints : self.regularConstraints)
         }
         
         currencyTapView.constrain([
-                   currencyTapView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 0),
-                   currencyTapView.trailingAnchor.constraint(equalTo: self.timeStampStackView.leadingAnchor, constant: 0),
-                   currencyTapView.topAnchor.constraint(equalTo: primaryLabel.topAnchor, constant: 0),
-                   currencyTapView.bottomAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: C.padding[1]) ])
-
-         let gr = UITapGestureRecognizer(target: self, action: #selector(currencySwitchTapped))
-         currencyTapView.addGestureRecognizer(gr)
+                                    currencyTapView.leadingAnchor.constraint(equalTo: headerView.leadingAnchor, constant: 0),
+                                    currencyTapView.trailingAnchor.constraint(equalTo: self.timeStampStackView.leadingAnchor, constant: 0),
+                                    currencyTapView.topAnchor.constraint(equalTo: primaryLabel.topAnchor, constant: 0),
+                                    currencyTapView.bottomAnchor.constraint(equalTo: primaryLabel.bottomAnchor, constant: C.padding[1]) ])
+        
+        let gr = UITapGestureRecognizer(target: self, action: #selector(currencySwitchTapped))
+        currencyTapView.addGestureRecognizer(gr)
     }
-    
+    //MARK: - Adding Subscriptions
     private func addSubscriptions() {
-        
-        
-        
+         
         guard let store = self.store else {
             NSLog("ERROR - Store not passed")
             return
         }
         
         guard let primaryLabel = self.primaryBalanceLabel ,
-            let secondaryLabel = self.secondaryBalanceLabel else {
-          NSLog("ERROR: Price labels not initialized")
-                return
+              let secondaryLabel = self.secondaryBalanceLabel else {
+            NSLog("ERROR: Price labels not initialized")
+            return
         }
         
         store.subscribe(self, selector: { $0.walletState.syncProgress != $1.walletState.syncProgress },
                         callback: { _ in
                             self.tabBar.selectedItem = self.tabBar.items?.first
-        })
- 
+                        })
+        
         store.lazySubscribe(self,
                             selector: { $0.isLtcSwapped != $1.isLtcSwapped },
                             callback: { self.isLtcSwapped = $0.isLtcSwapped })
@@ -205,7 +200,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
                                     
                                 }
                                 self.exchangeRate = $0.currentRate
-        })
+                            })
         
         store.lazySubscribe(self,
                             selector: { $0.maxDigits != $1.maxDigits},
@@ -216,7 +211,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
                                     primaryLabel.formatter = placeholderAmount.ltcFormat
                                     self.setBalances()
                                 }
-        })
+                            })
         
         store.subscribe(self,
                         selector: {$0.walletState.balance != $1.walletState.balance },
@@ -233,13 +228,13 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
             return
         }
         guard let primaryLabel = self.primaryBalanceLabel,
-            let secondaryLabel = self.secondaryBalanceLabel else {
-                NSLog("ERROR: Price labels not initialized")
-                return
+              let secondaryLabel = self.secondaryBalanceLabel else {
+            NSLog("ERROR: Price labels not initialized")
+            return
         }
-         
+        
         let amount = Amount(amount: balance, rate: rate, maxDigits: store.state.maxDigits)
-
+        
         if !hasInitialized {
             let amount = Amount(amount: balance, rate: exchangeRate!, maxDigits: store.state.maxDigits)
             NSLayoutConstraint.deactivate(isLTCSwapped ? self.regularConstraints : self.swappedConstraints)
@@ -256,7 +251,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
             if primaryLabel.isHidden {
                 primaryLabel.isHidden = false
             }
-
+            
             if secondaryLabel.isHidden {
                 secondaryLabel.isHidden = false
             }
@@ -277,9 +272,9 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         let fiatRate = Double(round(100*rate.rate)/100)
         let formattedFiatString = String(format: "%.02f", fiatRate)
         self.currentLTCPriceLabel.text = Currency.getSymbolForCurrencyCode(code: rate.code)! + formattedFiatString
-       
+        
     }
-   
+    
     private func transform(forView: UIView) ->  CGAffineTransform {
         forView.transform = .identity //Must reset the view's transform before we calculate the next transform
         let scaleFactor: CGFloat = smallFontSize/largeFontSize
@@ -290,7 +285,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
     }
     
     override func viewWillAppear(_ animated: Bool) {
-
+        
         super.viewWillAppear(animated)
         
         guard let array = self.tabBar.items else {
@@ -301,68 +296,66 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         array.forEach { item in
             
             switch item.tag {
-            case 0: item.title = S.History.barItemTitle
-            case 1: item.title = S.Send.barItemTitle
-            //DEV: re-add when launching v1
-            //case 2: item.title = S.LitecoinCard.barItemTitle
-            case 2: item.title = S.Receive.barItemTitle
-            case 3: item.title = S.BuyCenter.barItemTitle
-            default:
-                item.title = "NO-TITLE"
-                NSLog("ERROR: UITabbar item count is wrong")
+                case 0: item.title = S.History.barItemTitle
+                case 1: item.title = S.Send.barItemTitle
+                case 2: item.title = S.LitecoinCard.barItemTitle
+                case 3: item.title = S.Receive.barItemTitle
+                case 4: item.title = S.BuyCenter.barItemTitle
+                default:
+                    item.title = "NO-TITLE"
+                    NSLog("ERROR: UITabbar item count is wrong")
             }
         }
-     }
+    }
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         self.displayContentController(contentController: viewControllers[kInitialChildViewControllerIndex])
     }
- 
+    
     func displayContentController(contentController:UIViewController) {
         
         //MARK: - Tab View Controllers Configuration
         switch NSStringFromClass(contentController.classForCoder) {
-        case "loafwallet.TransactionsViewController":
-
-            guard let transactionVC = contentController as? TransactionsViewController else  {
-                return
-            }
-            
-            transactionVC.store = self.store
-            transactionVC.walletManager = self.walletManager
-            transactionVC.isLtcSwapped = self.store?.state.isLtcSwapped
-        
-            //DEV: Unhiding when launching Litecoin Card v1
-            // case "loafwallet.CardViewController":
-            // guard let cardVC = contentController as? CardViewController else  {
-            //  return
-            //  }
-            //
-            // cardVC.parentFrame = self.containerView.frame
-           
+            case "loafwallet.TransactionsViewController":
+                
+                guard let transactionVC = contentController as? TransactionsViewController else  {
+                    return
+                }
+                
+                transactionVC.store = self.store
+                transactionVC.walletManager = self.walletManager
+                transactionVC.isLtcSwapped = self.store?.state.isLtcSwapped
+                
+            case "loafwallet.CardViewController":
+                guard let cardVC = contentController as? CardViewController else  {
+                    return
+                }
+                
+                cardVC.parentFrame = self.containerView.frame
+                
             case "loafwallet.BuyTableViewController":
                 guard let buyVC = contentController as? BuyTableViewController else  {
                     return
-            }
-            buyVC.store = self.store
-            buyVC.walletManager = self.walletManager
-            
-        case "loafwallet.SendLTCViewController":
-            guard let sendVC = contentController as? SendLTCViewController else  {
-                return
-            }
-            
-            sendVC.store = self.store
-            
-        case "loafwallet.ReceiveLTCViewController":
-            guard let receiveVC = contentController as? ReceiveLTCViewController else  {
-                return
-            }
-            receiveVC.store = self.store
-            
-        default:
-            fatalError("Tab viewController not set")
+                }
+                buyVC.store = self.store
+                buyVC.walletManager = self.walletManager
+                
+            case "loafwallet.SendLTCViewController":
+                guard let sendVC = contentController as? SendLTCViewController else  {
+                    return
+                }
+                
+                sendVC.store = self.store
+                
+            case "loafwallet.ReceiveLTCViewController":
+                guard let receiveVC = contentController as? ReceiveLTCViewController else  {
+                    return
+                }
+                receiveVC.store = self.store
+                
+            default:
+                fatalError("Tab viewController not set")
         }
         self.exchangeRate = TransactionManager.sharedInstance.rate
         
@@ -378,14 +371,12 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
         contentController.view .removeFromSuperview()
         contentController.removeFromParentViewController()
     }
-      
+    
     func tabBar(_ tabBar: UITabBar, didSelect item: UITabBarItem) {
         
         if let tempActiveController = activeController {
             self.hideContentController(contentController: tempActiveController)
         }
-        
-        //DEV: This happens because it relies on the tab in the storyboard tag
         self.displayContentController(contentController: viewControllers[item.tag])
     }
 }
@@ -397,11 +388,11 @@ extension TabBarViewController {
         guard let store = self.store else { return }
         guard let isLTCSwapped = self.isLtcSwapped else { return }
         guard let primaryLabel = self.primaryBalanceLabel,
-            let secondaryLabel = self.secondaryBalanceLabel else {
-                NSLog("ERROR: Price labels not initialized")
-                return
+              let secondaryLabel = self.secondaryBalanceLabel else {
+            NSLog("ERROR: Price labels not initialized")
+            return
         }
-
+        
         UIView.spring(0.7, animations: {
             primaryLabel.transform = primaryLabel.transform.isIdentity ? self.transform(forView: primaryLabel) : .identity
             secondaryLabel.transform = secondaryLabel.transform.isIdentity ? self.transform(forView: secondaryLabel) : .identity
@@ -413,8 +404,3 @@ extension TabBarViewController {
         store.perform(action: CurrencyChange.toggle())
     }
 }
-
-
-
-
- 


### PR DESCRIPTION
## Goal
Show the Litecoin Card tab in the production version of Litewallet.

## Approach
1. Unhide the code and refactor the `Card` tab in the TabBarView
2. Test the functionality of the tabs
3. Set the version of the LitewalletPartnerAPI Swift Package (`v0.5.0`) with the prod endpoints

## Commits
- Unhiding the tab
- Update the LitewalletPartnerAPI Swift package

## Screenshots

Before | After
-------|-------
![with-price](https://user-images.githubusercontent.com/2899463/105560481-b7867d80-5d0b-11eb-8ce1-18519cff4b2c.gif)|![slight-tilt](https://user-images.githubusercontent.com/2899463/105560505-d38a1f00-5d0b-11eb-93b2-f18a69573608.gif)
