### PR TITLE
[Feature] Add animation when refreshing LTC price

### DIFF
--- a/loafwallet/TabBarViewController.swift
+++ b/loafwallet/TabBarViewController.swift
@@ -220,6 +220,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
                             } })
     }
     
+    /// This is called when the price changes
     private func setBalances() {
         guard let rate = exchangeRate, let store = self.store, let isLTCSwapped = self.isLtcSwapped else {
             NSLog("ERROR: Rate, Store not initialized")
@@ -266,15 +267,29 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
             primaryLabel.transform = transform(forView: primaryLabel)
         }
         
-        self.timeStampLabel.text = S.TransactionDetails.priceTimeStampLabel + " " + dateFormatter.string(from: Date())
+        // Time and Price Label
+        let timeText = S.TransactionDetails.priceTimeStampLabel + " " + dateFormatter.string(from: Date())
         let fiatRate = Double(round(100*rate.rate)/100)
         let formattedFiatString = String(format: "%.02f", fiatRate)
-        self.currentLTCPriceLabel.text = Currency.getSymbolForCurrencyCode(code: rate.code)! + formattedFiatString
+        let newPrice = Currency.getSymbolForCurrencyCode(code: rate.code)! + formattedFiatString
         
+        self.currentLTCPriceLabel.text =  " "
+        self.timeStampLabel.text = timeText
+
+        // Transitions when the data changes
+        UIView.transition(with: self.currentLTCPriceLabel,
+                          duration: 2.0,
+                          options: .transitionFlipFromLeft,
+                          animations: { [weak self] in
+                            self?.currentLTCPriceLabel.text =  newPrice
+                          }, completion: nil) 
     }
     
+    /// Transform LTC and Fiat  Balances
+    /// - Parameter forView: Views
+    /// - Returns: the inverse transform
     private func transform(forView: UIView) ->  CGAffineTransform {
-        forView.transform = .identity //Must reset the view's transform before we calculate the next transform
+        forView.transform = .identity
         let scaleFactor: CGFloat = smallFontSize/largeFontSize
         let deltaX = forView.frame.width * (1-scaleFactor)
         let deltaY = forView.frame.height * (1-scaleFactor)

--- a/loafwallet/TabBarViewController.swift
+++ b/loafwallet/TabBarViewController.swift
@@ -282,7 +282,7 @@ class TabBarViewController: UIViewController, Subscriber, Trackable, UITabBarDel
                           options: .transitionFlipFromLeft,
                           animations: { [weak self] in
                             self?.currentLTCPriceLabel.text =  newPrice
-                          }, completion: nil) 
+                          }, completion: nil)
     }
     
     /// Transform LTC and Fiat  Balances
@@ -414,6 +414,8 @@ extension TabBarViewController {
             NSLayoutConstraint.deactivate(!isLTCSwapped ? self.regularConstraints : self.swappedConstraints)
             NSLayoutConstraint.activate(!isLTCSwapped ? self.swappedConstraints : self.regularConstraints)
             self.view.layoutIfNeeded()
+            
+            LWAnalytics.logEventWithParameters(itemName: ._20200207_DTHB)
             
         }) { _ in }
         store.perform(action: CurrencyChange.toggle())

--- a/loafwallet/src/Constants/Constants.swift
+++ b/loafwallet/src/Constants/Constants.swift
@@ -37,6 +37,8 @@ enum CustomEvent: String {
     case _20201121_SIL = "STARTED_IFPS_LOOKUP"
     case _20201121_DRIA = "DID_RESOLVE_IPFS_ADDRESS"
     case _20201121_FRIA = "FAILED_RESOLVE_IPFS_ADDRESS"
+    case _20200207_DTHB = "DID_TAP_HEADER_BALANCE"
+
 }
 
 struct FoundationSupport {


### PR DESCRIPTION
## Goal
Make it more clear for users to see when the price updates

## Concerns
A few users get confused on the current price (top right) and their balance (top left)
This was a quick fix that let people know what the  labels do.

Also adding a test point to see how often people change the balance label....maybe they don't  know?


|New Feature: _Animate LTC Price_ |
|---------------|
|![animation-fi](https://user-images.githubusercontent.com/2899463/107266671-c07e8b00-6a3d-11eb-84df-a49c2fc84f10.gif)|

