### PR TITLE
🥳[Feature] Add reset forgot litecoin password

### DIFF
--- a/loafwallet.xcodeproj/project.pbxproj
+++ b/loafwallet.xcodeproj/project.pbxproj
@@ -42,7 +42,8 @@
 		22A9A9481DF61945000F0016 /* BRBitID.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9341DF61945000F0016 /* BRBitID.swift */; };
 		22A9A9491DF61945000F0016 /* BRBSPatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9351DF61945000F0016 /* BRBSPatch.swift */; };
 		22A9A94A1DF61945000F0016 /* BRCameraPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9361DF61945000F0016 /* BRCameraPlugin.swift */; };
-		22A9A94B1DF61945000F0016 /* BRCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9371DF61945000F0016 /* BRCoding.swift */; };
+		22A9A94B1DF61945000F0016 /* BRCoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9371DF61945000F0016 /* BRCoding.swift 
+- Added UD Error Codes*/; };
 		22A9A94C1DF61945000F0016 /* BRGeoLocationPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9381DF61945000F0016 /* BRGeoLocationPlugin.swift */; };
 		22A9A94D1DF61945000F0016 /* BRHTTPFileMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A9391DF61945000F0016 /* BRHTTPFileMiddleware.swift */; };
 		22A9A94E1DF61945000F0016 /* BRHTTPIndexMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A9A93A1DF61945000F0016 /* BRHTTPIndexMiddleware.swift */; };
@@ -269,7 +270,10 @@
 		C30029E225D0185500F08C2B /* StandardDividerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30029E125D0185500F08C2B /* StandardDividerView.swift */; };
 		C30029EB25D019BC00F08C2B /* CopyButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30029EA25D019BC00F08C2B /* CopyButtonView.swift */; };
 		C30AFB4E2598FC1B00CDCF69 /* BuildFile in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* SwiftPackageProductDependency */; };
+		C30899792616426800EE6A40 /* ForgotAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30899782616426800EE6A40 /* ForgotAlertViewModel.swift */; };
+		C30AFB4E2598FC1B00CDCF69 /* LitewalletPartnerAPI in Frameworks */ = {isa = PBXBuildFile; productRef = C30AFB4D2598FC1B00CDCF69 /* LitewalletPartnerAPI */; };
 		C30AFB642598FFB200CDCF69 /* PartnerAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30AFB632598FFB200CDCF69 /* PartnerAPIManager.swift */; };
+		C316CF49261887FC00E4C09B /* UIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C316CF48261887FC00E4C09B /* UIApplication+Extension.swift */; };
 		C32142EA25C97CD900BECCD0 /* TransactionCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32142E925C97CD900BECCD0 /* TransactionCellView.swift */; };
 		C32142FA25C988C800BECCD0 /* TransactionCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C32142F925C988C800BECCD0 /* TransactionCellViewModel.swift */; };
 		C3270B99259BF7F20073DA7B /* LitecoinCardUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3270B98259BF7F20073DA7B /* LitecoinCardUser.swift */; };
@@ -1443,7 +1447,9 @@
 		88220266EF282D1F355BB238 /* Pods-loafwallet.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-loafwallet.release.xcconfig"; path = "Target Support Files/Pods-loafwallet/Pods-loafwallet.release.xcconfig"; sourceTree = "<group>"; };
 		C30029E125D0185500F08C2B /* StandardDividerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StandardDividerView.swift; sourceTree = "<group>"; };
 		C30029EA25D019BC00F08C2B /* CopyButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CopyButtonView.swift; sourceTree = "<group>"; };
+		C30899782616426800EE6A40 /* ForgotAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForgotAlertViewModel.swift; sourceTree = "<group>"; };
 		C30AFB632598FFB200CDCF69 /* PartnerAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PartnerAPIManager.swift; sourceTree = "<group>"; };
+		C316CF48261887FC00E4C09B /* UIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+Extension.swift"; sourceTree = "<group>"; };
 		C32142E925C97CD900BECCD0 /* TransactionCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionCellView.swift; sourceTree = "<group>"; };
 		C32142F925C988C800BECCD0 /* TransactionCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransactionCellViewModel.swift; sourceTree = "<group>"; };
 		C3270B98259BF7F20073DA7B /* LitecoinCardUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LitecoinCardUser.swift; sourceTree = "<group>"; };
@@ -3180,6 +3186,7 @@
 				C3F7BCDB25FEC6AC00694C28 /* AlertFailureView.swift */,
 				C3F7BCDA25FEC6AC00694C28 /* DomainResolutionFailure.swift */,
 				C3F7BCD925FEC6AC00694C28 /* FailedAlertView.swift */,
+				C30899782616426800EE6A40 /* ForgotAlertViewModel.swift */,
 			);
 			name = Alerts;
 			sourceTree = "<group>";
@@ -3243,6 +3250,7 @@
 				C3BD4A5225975C6000D97079 /* View+Extension.swift */,
 				C32DAE0625925B7E003FC978 /* Color+Extension.swift */,
 				CE20C8FB1DBB0F3A00C8397A /* UIColor+Extension.swift */,
+				C316CF48261887FC00E4C09B /* UIApplication+Extension.swift */,
 				CE20C90D1DBE52B000C8397A /* UIView+BRWAdditions.swift */,
 				CE20C9161DBE6F2A00C8397A /* UIButton+BRWAdditions.swift */,
 				CEAA9E901DC0FDFE0066731D /* UIViewPropertyAnimator+BRWAdditions.swift */,
@@ -4207,6 +4215,7 @@
 				2218BD771E8F55430091D5E8 /* BRAPIClient+Assets.swift in Sources */,
 				2228734D1E916F7C0044BA15 /* BRAPIClient+Features.swift in Sources */,
 				22A9A94D1DF61945000F0016 /* BRHTTPFileMiddleware.swift in Sources */,
+				C316CF49261887FC00E4C09B /* UIApplication+Extension.swift in Sources */,
 				CE8644251F2C160200033129 /* ConfirmationViewController.swift in Sources */,
 				CEE1F5631DF13E5A00D733AD /* ModalHeaderView.swift in Sources */,
 				CE5F21DB1E4A93A500C47B8E /* LoginTransitionDelegate.swift in Sources */,
@@ -4363,6 +4372,7 @@
 				CEF3E8361DE60222007C0A9E /* ModalNavigationController.swift in Sources */,
 				CEB909FA1E5FF242001804DC /* RecoverWalletIntroViewController.swift in Sources */,
 				CE25BF911DF9ADE700BC67B6 /* UIImage+Utils.swift in Sources */,
+				C30899792616426800EE6A40 /* ForgotAlertViewModel.swift in Sources */,
 				CEBF33041DDE17A600348FC6 /* Transaction.swift in Sources */,
 				CEAA9E911DC0FDFE0066731D /* UIViewPropertyAnimator+BRWAdditions.swift in Sources */,
 				22E773041EE7813000397E0E /* Bonjour.swift in Sources */,
@@ -5535,7 +5545,7 @@
 			repositoryURL = "https://github.com/litecoin-foundation/LitewalletPartnerAPI.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.0;
+				minimumVersion = 0.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/loafwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/loafwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/litecoin-foundation/LitewalletPartnerAPI.git",
         "state": {
           "branch": null,
-          "revision": "5fafe40f4eac370440d39192d73916a387b0f36e",
-          "version": "0.5.0"
+          "revision": "945c891c9606c48de2266daf87e0303f8cf39ea8",
+          "version": "0.7.0"
         }
       }
     ]

--- a/loafwallet/ForgotAlertViewModel.swift
+++ b/loafwallet/ForgotAlertViewModel.swift
@@ -26,7 +26,7 @@ class ForgotAlertViewModel: ObservableObject {
         PartnerAPI.shared.forgotPassword(email: emailString) { (responseMessage, code) in
              
             DispatchQueue.main.async {
-                self.detailMessage = "\(code): "+responseMessage
+                self.detailMessage = "\(code): " + responseMessage
                 completion()
             }
         }

--- a/loafwallet/ForgotAlertViewModel.swift
+++ b/loafwallet/ForgotAlertViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  ForgotAlertViewModel.swift
+//  loafwallet
+//
+//  Created by Kerry Washington on 4/1/21.
+//  Copyright © 2021 Litecoin Foundation. All rights reserved.
+//
+
+import Foundation
+import SwiftUI
+import LitewalletPartnerAPI
+
+class ForgotAlertViewModel: ObservableObject {
+    
+    //MARK: - Combine Variables
+    @Published
+    var emailString: String = ""
+    
+    @Published
+    var detailMessage: String = S.LitecoinCard.resetPasswordDetail
+    
+    init() { }
+    
+    func resetPassword(completion: @escaping () -> Void) {
+        
+        PartnerAPI.shared.forgotPassword(email: emailString) { (responseMessage, code) in
+             
+            DispatchQueue.main.async {
+                self.detailMessage = "\(code): "+responseMessage
+                completion()
+            }
+        }
+    }
+}
+

--- a/loafwallet/ForgotView.swift
+++ b/loafwallet/ForgotView.swift
@@ -8,6 +8,10 @@ import SwiftUI
 
 struct ForgotAlertView<Presenting>: View where Presenting: View {
     
+    //MARK: - Combine Variables
+    @ObservedObject
+    var viewModel = ForgotAlertViewModel()
+
     @Binding
     var isShowingForgot: Bool
     
@@ -18,6 +22,12 @@ struct ForgotAlertView<Presenting>: View where Presenting: View {
     
     var mainMessage: String
     
+    @State
+    var detailMessage: String = S.LitecoinCard.resetPasswordDetail
+    
+    @State
+    var didCheckEmailAddress: Bool = false
+    
     var body: some View {
         GeometryReader { (deviceSize: GeometryProxy) in
             HStack{
@@ -25,29 +35,57 @@ struct ForgotAlertView<Presenting>: View where Presenting: View {
                 ZStack {
                     self.presenting.disabled(isShowingForgot)
                     VStack {
-                        Text(S.LitecoinCard.resetPassword)
-                            .font(Font(UIFont.barlowBold(size: 20.0)))
+                        Text(S.LitecoinCard.forgotPassword)
+                            .font(Font(UIFont.barlowSemiBold(size: 20.0)))
                             .padding()
                             .foregroundColor(Color.white)
-                        
-                        Text(S.LitecoinCard.visitToReset)
-                            .font(Font(UIFont.barlowMedium(size: 18.0)))
+ 
+                        Text(detailMessage)
+                            .font(Font(UIFont.barlowRegular(size: 18.0)))
                             .foregroundColor(Color.white)
-                            .padding(.all, 10)
+                            .multilineTextAlignment(.leading)
+                            .padding(.bottom, 12)
+                            .padding([.leading, .trailing], 8)
+                            .onReceive(viewModel.$detailMessage, perform: { updatedMessage in
+                                detailMessage = updatedMessage
+                            })
                         
-                        Divider().background(Color.white)
+                        TextField(emailString, text: didCheckEmailAddress ? .constant("") : $viewModel.emailString)
+                            .font(Font(UIFont.barlowMedium(size: 16.0)))
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .keyboardType(.emailAddress)
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .padding(.all, 8)
+                        
                         HStack {
+                            
+                            // Reset password button
                             Button(action: {
                                 withAnimation {
-                                    self.isShowingForgot.toggle()
+                                    viewModel.resetPassword {
+                                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5, execute: {
+                                            self.isShowingForgot.toggle()
+                                            UIApplication.shared.endEditing()
+                                            didCheckEmailAddress = true
+                                            detailMessage = S.LitecoinCard.resetPasswordDetail
+                                        })
+                                    }
                                 }
                             }) {
-                                Text(S.Button.ok)
+                                Text(S.LitecoinCard.resetPassword)
                                     .frame(minWidth:0, maxWidth: .infinity)
-                                    .padding()
                                     .font(Font(UIFont.barlowBold(size: 20.0)))
                                     .foregroundColor(Color.white)
+                                    .padding(.all, 8)
+                                    .overlay(
+                                    RoundedRectangle(cornerRadius:4)
+                                        .stroke(Color(UIColor.white), lineWidth: 1)
+                                )
+                                .padding([.leading, .trailing], 20)
+                                .padding([.top,.bottom], 10)
                             }
+                             
                         }
                     }
                     .padding()
@@ -58,7 +96,7 @@ struct ForgotAlertView<Presenting>: View where Presenting: View {
                     .background(Color(UIColor.liteWalletBlue))
                     .cornerRadius(8)
                     .frame(
-                        width: deviceSize.size.width * 0.8,
+                        width: deviceSize.size.width * 0.85,
                         height: deviceSize.size.height * 0.9
                     )
                     .shadow(color: .black, radius: 10, x: 5, y: 5)

--- a/loafwallet/UIApplication+Extension.swift
+++ b/loafwallet/UIApplication+Extension.swift
@@ -1,0 +1,16 @@
+//
+//  UIApplication+Extension.swift
+//  loafwallet
+//
+//  Created by Kerry Washington on 4/3/21.
+//  Copyright © 2021 Litecoin Foundation. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+extension UIApplication {
+    func endEditing() {
+        sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+    }
+}

--- a/loafwallet/src/Constants/Strings.swift
+++ b/loafwallet/src/Constants/Strings.swift
@@ -124,8 +124,9 @@ enum S {
         static let failedlogin = NSLocalizedString("LitecoinCard.failed.login", value: "**Failed Login**", comment: "Failed Login") 
         static let logout = NSLocalizedString("LitecoinCard.logout", value: "**Logout**", comment: "Logout")
         static let forgotPassword = NSLocalizedString("LitecoinCard.forgotPassword", value: "**Forgot password?**", comment: "Forgot password?")
+        static let resetPassword = NSLocalizedString("LitecoinCard.resetPassword", value: "**Reset password**", comment: "Reset password")
+        static let resetPasswordDetail = NSLocalizedString("LitecoinCard.resetPasswordDetail", value: "**Enter the email that you used to register for your Litecoin Card and check for an email from support@litecoin.getblockcard.com.**", comment: "Reset password detail")
         static let visitToReset = NSLocalizedString("LitecoinCard.visit.toReset", value: "**Reset Litecoin card visit**", comment: "Litecoin card visit")
-        static let resetPassword = NSLocalizedString("LitecoinCard.resetPassword", value: "**Reset Litecoin card password**", comment: "Reset Litecoin card password")
         static let registerCard = NSLocalizedString("LitecoinCard.registerCard", value: "**Register**", comment: "Register")
         static let registeringUser = NSLocalizedString("LitecoinCard.registering.user", value: "**Registering user...**", comment: "Registering user...")
         

--- a/loafwallet/src/Strings/Base.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/Base.lproj/Localizable.strings
@@ -1380,7 +1380,7 @@
 
 /* UDSystemError */
 "Send.UnstoppableDomains.udSystemError" = "System lookup problem. [Error: %2$d]";
-
+ 
 /* Balance */
 "ManageWallet.balance" = "Balance";
 
@@ -1389,3 +1389,7 @@
 
 /* Moonpay Title */
 "BuyCenter.moonpayTitle" = "Moonpay";
+ 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Enter the email address associated with your Litecoin Card account & look for an email with reset instructions.";
+ 

--- a/loafwallet/src/Strings/da.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/da.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Nulstille kodeord";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Indtast den e-mail-adresse, der er knyttet til din Litecoin Card-konto, og se efter en e-mail med nulstillingsinstruktioner.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Besøg https://litecoin.dashboard.getblockcard.com/password/forgot for at nulstille din adgangskode.";
 

--- a/loafwallet/src/Strings/de.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/de.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Passwort zurücksetzen";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Geben Sie die E-Mail-Adresse ein, die Ihrem Litecoin Card-Konto zugeordnet ist, und suchen Sie nach einer E-Mail mit Anweisungen zum Zurücksetzen.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Besuchen Sie https://litecoin.dashboard.getblockcard.com/password/forgot, um Ihr Passwort zurückzusetzen.";
 

--- a/loafwallet/src/Strings/en.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/en.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Reset password";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Enter the email address associated with your Litecoin Card account & look for an email with reset instructions.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Visit https://litecoin.dashboard.getblockcard.com/password/forgot\nto reset your password.";
 

--- a/loafwallet/src/Strings/es.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/es.lproj/Localizable.strings
@@ -485,6 +485,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Restablecer la contraseña";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Ingrese la dirección de correo electrónico asociada con su cuenta de tarjeta Litecoin y busque un correo electrónico con instrucciones para restablecer.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Visita https://litecoin.dashboard.getblockcard.com/password/forgot para restablecer tu contraseña.";
 

--- a/loafwallet/src/Strings/fr.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/fr.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Réinitialiser le mot de passe";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Entrez l'adresse e-mail associée à votre compte Litecoin Card et recherchez un e-mail avec des instructions de réinitialisation.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Visitez le site https://litecoin.dashboard.getblockcard.com/password/forgot pour réinitialiser votre mot de passe.";
 

--- a/loafwallet/src/Strings/id.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/id.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Setel ulang kata sandi";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Masukkan alamat email yang terkait dengan akun Kartu Litecoin Anda & cari email dengan instruksi reset.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Kunjungi https://litecoin.dashboard.getblockcard.com/password/forgot untuk mengatur ulang kata sandi Anda.";
 

--- a/loafwallet/src/Strings/it.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/it.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Resetta la password";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Inserisci l'indirizzo e-mail associato al tuo account Litecoin Card e cerca un'e-mail con le istruzioni per il ripristino.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Visita https://litecoin.dashboard.getblockcard.com/password/forgot per reimpostare la tua password.";
 

--- a/loafwallet/src/Strings/ja.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/ja.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "パスワードを再設定する";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "ライトコインカードアカウントに関連付けられているメールアドレスを入力し、リセット手順が記載されたメールを探します。";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "https://litecoin.dashboard.getblockcard.com/password/forgot にアクセスしてパスワードをリセットしてください。";
 

--- a/loafwallet/src/Strings/ko.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/ko.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "암호를 재설정";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "라이트 코인 카드 계정과 연결된 이메일 주소를 입력하고 재설정 지침이있는 이메일을 찾으십시오.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "https://litecoin.dashboard.getblockcard.com/password/forgot을 방문하여 암호를 재설정하십시오.";
 

--- a/loafwallet/src/Strings/nl.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/nl.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Wachtwoord opnieuw instellen";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Voer het e-mailadres in dat is gekoppeld aan uw Litecoin Card-account en zoek een e-mail met resetinstructies.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Ga naar https://litecoin.dashboard.getblockcard.com/password/forgot om uw wachtwoord te resetten.";
 

--- a/loafwallet/src/Strings/pt.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/pt.lproj/Localizable.strings
@@ -485,6 +485,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Redefinir senha";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Digite o endereço de e-mail associado à sua conta do cartão Litecoin e procure um e-mail com as instruções de reinicialização.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Visite https://litecoin.dashboard.getblockcard.com/password/forgot para redefinir a sua palavra-passe.";
 

--- a/loafwallet/src/Strings/ru.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/ru.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Сброс пароля";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Введите адрес электронной почты, связанный с вашей учетной записью Litecoin Card, и найдите письмо с инструкциями по сбросу.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Посетите https://litecoin.dashboard.getblockcard.com/password/forgot, чтобы сбросить пароль.";
 

--- a/loafwallet/src/Strings/sv.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/sv.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "Återställ lösenord";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "Ange e-postadressen som är kopplad till ditt Litecoin-kortkonto och leta efter ett e-postmeddelande med återställningsinstruktioner.";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "Besök https://litecoin.dashboard.getblockcard.com/password/forgot för att återställa ditt lösenord.";
 

--- a/loafwallet/src/Strings/zh-Hans.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/zh-Hans.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "重设密码";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "输入与您的Litecoin卡帐户关联的电子邮件地址，并查找包含重置说明的电子邮件。";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "请访问 https://litecoin.dashboard.getblockcard.com/password/forgot 重置您的密码。";
 

--- a/loafwallet/src/Strings/zh-Hant.lproj/Localizable.strings
+++ b/loafwallet/src/Strings/zh-Hant.lproj/Localizable.strings
@@ -484,6 +484,9 @@
 /* Reset Litecoin card password */
 "LitecoinCard.resetPassword" = "重設密碼";
 
+/* Reset password detail */
+"LitecoinCard.resetPasswordDetail" = "輸入與您的Litecoin卡帳戶關聯的電子郵件地址，並查找包含重置說明的電子郵件。";
+
 /* Litecoin card visit */
 "LitecoinCard.visit.toReset" = "訪問https://litecoin.dashboard.getblockcard.com/password/forgot重設密碼。";
 


### PR DESCRIPTION
## Goals
Adds functionality of Reset Password so the user can trigger a reset of the Litecoin Card password.

## Features Added
- Button now opens a modal with a Textfield and instructions
- Keyboard dismisses when the reset button is tapped
- Added Localizations

## Screenshots
|Before|After|
|-------|-----|
|![reset-password-before](https://user-images.githubusercontent.com/2899463/113515329-becbd200-956b-11eb-9333-f51d3df5c2a2.gif)|![reset-password-after](https://user-images.githubusercontent.com/2899463/113515334-c68b7680-956b-11eb-8c51-e3cc7c12a734.gif)|

Closes #243 